### PR TITLE
Extending RVV support to vrsub/vfrsub/vfcvt.rtz and vluxei

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -1897,6 +1897,7 @@ decode QUADRANT default Unknown::unknown() {
             0x3: decode VFUNC_6 { // OPIVI
                 0x00: VectorData2SrcOp::vadd_vi();
                 0x02: VectorData2SrcOp::vsub_vi();
+                0x03: VectorData2SrcOp::vrsub_vi();
                 0x09: VectorData2SrcOp::vand_vi();
                 0x0A: VectorData2SrcOp::vor_vi();
                 0x0B: VectorData2SrcOp::vxor_vi();
@@ -1924,6 +1925,7 @@ decode QUADRANT default Unknown::unknown() {
             0x4: decode VFUNC_6 { // OPIVX
                 0x00: VectorData2SrcOp::vadd_vx();
                 0x02: VectorData2SrcOp::vsub_vx();
+                0x03: VectorData2SrcOp::vrsub_vx();
                 0x04: VectorData2SrcOp::vminu_vx();
                 0x05: VectorData2SrcOp::vmin_vx();
                 0x06: VectorData2SrcOp::vmaxu_vx();
@@ -1951,6 +1953,7 @@ decode QUADRANT default Unknown::unknown() {
             0x5: decode VFUNC_6 { // OPFVF
                 0x00: VectorData2SrcOp::vfadd_vf();
                 0x02: VectorData2SrcOp::vfsub_vf();
+                0x03: VectorData2SrcOp::vfrsub_vf();
                 0x04: VectorData2SrcOp::vfmin_vf();
                 0x06: VectorData2SrcOp::vfmax_vf();
                 0x08: VectorData2SrcOp::vfsgnj_vf();

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -433,6 +433,7 @@ decode QUADRANT default Unknown::unknown() {
                 0x0: decode LUMOP {
                     0x0: VectorMemLoadOp::vle16_v();
                 }
+                0x1:VectorMemLoadOp::vluxei16_v();
                 0x2:VectorMemLoadOp::vlse16_v();
                 0x3:VectorMemLoadOp::vloxei16_v();
             }
@@ -440,6 +441,7 @@ decode QUADRANT default Unknown::unknown() {
                 0x0: decode LUMOP {
                     0x0: VectorMemLoadOp::vle32_v();
                 }
+                0x1:VectorMemLoadOp::vluxei32_v();
                 0x2:VectorMemLoadOp::vlse32_v();
                 0x3:VectorMemLoadOp::vloxei32_v();
             }
@@ -447,6 +449,7 @@ decode QUADRANT default Unknown::unknown() {
                 0x0: decode LUMOP {
                     0x0: VectorMemLoadOp::vle64_v();
                 }
+                0x1:VectorMemLoadOp::vluxei64_v();
                 0x2:VectorMemLoadOp::vlse64_v();
                 0x3:VectorMemLoadOp::vloxei64_v();
             }

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -1838,6 +1838,9 @@ decode QUADRANT default Unknown::unknown() {
                     0x01: VectorConvertFPToIntOp::vfcvt_x_f_v();    // Convert float to signed integer.
                     0x02: VectorConvertIntToFPOp::vfcvt_f_xu_v();   // Convert unsigned integer to float.
                     0x03: VectorConvertIntToFPOp::vfcvt_f_x_v();    // Convert signed integer to float.
+
+                    0x06: VectorConvertIntToFPOp::vfcvt_rtz_xu_f_v();   // Convert unsigned integer to float (round towards zero).
+                    0x07: VectorConvertIntToFPOp::vfcvt_rtz_x_f_v();    // Convert signed integer to float (round towards zero).
                     // Widening Operations are not fully supported. WIP
                     0x08: VectorWConvertFPToIntOp::vfwcvt_xu_f_v(); // Convert float to double-width unsigned integer.
                     0x09: VectorWConvertFPToIntOp::vfwcvt_x_f_v();  // Convert float to double-width signed integer.

--- a/src/cpu/vector_engine/vpu/multilane_wrapper/func_unit.hh
+++ b/src/cpu/vector_engine/vpu/multilane_wrapper/func_unit.hh
@@ -1828,7 +1828,7 @@ Datapath::compute_cvt_x_f_64_op( double Bitem, uint8_t Mitem,
 {
     long int Ditem=0;
     std::string operation = insn->getName();
-    numFP64_operations = numFP64_operations.value() + 1; // number of 32-bit FP operations
+    numFP64_operations = numFP64_operations.value() + 1; // number of 64-bit FP operations
 
     if ((operation == "vfcvt_x_f_v")) {
         Ditem = (long int)Bitem;
@@ -1838,6 +1838,18 @@ Datapath::compute_cvt_x_f_64_op( double Bitem, uint8_t Mitem,
 
     if ((operation == "vfcvt_xu_f_v")) {
         Ditem = (unsigned long int)Bitem;
+        DPRINTF(Datapath,"WB Instruction =  cast unsigned (%0.2lf) = %d\n",
+            Bitem, Ditem);
+    }
+
+    if ((operation == "vfcvt_rtz_x_f_v")) {
+        Ditem = (long int) trunc(Bitem);
+        DPRINTF(Datapath,"WB Instruction =  cast unsigned (%0.2lf) = %d\n",
+            Bitem, Ditem);
+    }
+
+    if ((operation == "vfcvt_rtz_xu_f_v")) {
+        Ditem = (unsigned long int) trunc(Bitem);
         DPRINTF(Datapath,"WB Instruction =  cast unsigned (%0.2lf) = %d\n",
             Bitem, Ditem);
     }
@@ -1862,6 +1874,18 @@ Datapath::compute_cvt_x_f_32_op( float Bitem, uint8_t Mitem,
     if ((operation == "vfcvt_xu_f_v")) {
         Ditem = (unsigned int)Bitem;
         DPRINTF(Datapath,"WB Instruction =  cast unsigned (%0.2f) = %d\n",
+            Bitem, Ditem);
+    }
+
+    if ((operation == "vfcvt_rtz_x_f_v")) {
+        Ditem = (int) truncf(Bitem);
+        DPRINTF(Datapath,"WB Instruction =  cast unsigned (%0.2lf) = %d\n",
+            Bitem, Ditem);
+    }
+
+    if ((operation == "vfcvt_rtz_xu_f_v")) {
+        Ditem = (unsigned int) truncf(Bitem);
+        DPRINTF(Datapath,"WB Instruction =  cast unsigned (%0.2lf) = %d\n",
             Bitem, Ditem);
     }
 

--- a/src/cpu/vector_engine/vpu/multilane_wrapper/func_unit.hh
+++ b/src/cpu/vector_engine/vpu/multilane_wrapper/func_unit.hh
@@ -50,6 +50,12 @@ Datapath::compute_float_fp_op(float Aitem, float Bitem, uint8_t Mitem,
             Aitem, Ditem);
     }
 
+    if (operation == "vfrsub_vf"){
+        Ditem = ((vm==1) || ((vm==0) && (Mitem==1))) ? Aitem - Bitem : Dstitem;
+        DPRINTF(Datapath,"WB Instruction = %f - %f  = %f  \n",Aitem,
+            Bitem, Ditem);
+    }
+
     if ((operation == "vfmul_vv") | (operation == "vfmul_vf")){
         Ditem = ((vm==1) || ((vm==0) && (Mitem==1))) ? Aitem * Bitem :Dstitem;
         DPRINTF(Datapath,"WB Instruction = %f * %f  = %f  \n",Aitem,

--- a/src/cpu/vector_engine/vpu/multilane_wrapper/inst_latency.hh
+++ b/src/cpu/vector_engine/vpu/multilane_wrapper/inst_latency.hh
@@ -131,6 +131,7 @@ Datapath::get_instruction_latency()
      *************************************************************************/
 
     if (   (operation == "vfcvt_x_f_v") || (operation == "vfcvt_xu_f_v")
+        || (operation == "vfcvt_rtz_x_f_v") || (operation == "vfcvt_rtz_xu_f_v")
         || (operation == "vfcvt_f_x_v") || (operation == "vfcvt_f_xu_v")) { 
         Oplatency           = 4;
     }


### PR DESCRIPTION
- decoding, datapath and default timing for fcvt.rtz
- decoding for vrsub (implementation was already developed)
- decoding and datapath for vfrsub.vf
- only vluxei decoding has been added (functionnality has not been checked)