### PR TITLE
RVV instruction additions and fixes for the week of Sept 12

### DIFF
--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -148,6 +148,24 @@ std::string VectorArithMacroInst::generateDisassembly(Addr pc,
     return ss.str();
 }
 
+std::string VectorVMUNARY0MicroInst::generateDisassembly(Addr pc,
+        const loader::SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    ss << mnemonic << ' ' << registerName(destRegIdx(0));
+    if (machInst.vm == 0) ss << ", v0.t";
+    return ss.str();
+}
+
+std::string VectorVMUNARY0MacroInst::generateDisassembly(Addr pc,
+        const loader::SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    ss << mnemonic << ' ' << registerName(destRegIdx(0));
+    if (machInst.vm == 0) ss << ", v0.t";
+    return ss.str();
+}
+
 std::string VleMicroInst::generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const
 {

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -165,6 +165,34 @@ class VectorArithMacroInst : public VectorMacroInst
             Addr pc, const loader::SymbolTable *symtab) const override;
 };
 
+class VectorVMUNARY0MicroInst : public VectorMicroInst
+{
+protected:
+    VectorVMUNARY0MicroInst(const char *mnem, ExtMachInst _machInst,
+                         OpClass __opClass, uint8_t _microVl,
+                         uint8_t _microIdx)
+        : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
+    {}
+
+    std::string generateDisassembly(
+            Addr pc, const loader::SymbolTable *symtab) const override;
+};
+
+class VectorVMUNARY0MacroInst : public VectorMacroInst
+{
+  protected:
+    VectorVMUNARY0MacroInst(const char* mnem, ExtMachInst _machInst,
+                         OpClass __opClass)
+        : VectorMacroInst(mnem, _machInst, __opClass)
+    {
+        this->flags[IsVector] = true;
+    }
+
+    std::string generateDisassembly(
+            Addr pc, const loader::SymbolTable *symtab) const override;
+};
+
+
 class VectorMemMicroInst : public VectorMicroInst
 {
   protected:

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -3234,11 +3234,19 @@ decode QUADRANT default Unknown::unknown() {
                                              ftype<et>((vu)Fs1_bits),
                                              false, true).v;
                     }}, OPFVF, VectorDummyOp);
+                    0x10: VectorNonSplitFormat::vfmv_s_f({{
+                        auto fd = ftype_freg<et>(freg(Fs1_bits));
+                        Vd_vu[0] = fd.v;
+                    }}, OPFVV, VectorDummyOp);
                     0x17: decode VM {
                         0x0: vfmerge_vfm({{
                             Vd_vu[i] = elem_mask(v0, ei)
                                     ? ftype<et>((vu)Fs1_bits).v
                                     : Vs2_vu[i];
+                        }}, OPFVF, VectorDummyOp);
+                        0x1: vfmv_v_f({{
+                            auto fd = ftype_freg<et>(freg(Fs1_bits));
+                            Vd_vu[i] = fd.v;
                         }}, OPFVF, VectorDummyOp);
                     }
                 }

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2448,6 +2448,16 @@ decode QUADRANT default Unknown::unknown() {
                                             ftype<et>(Vs3_vu[i]));
                         Vd_vu[i] = fd.v;
                     }}, OPFVV, VectorDummyOp);
+                    0x31: VectorReduceFloatWideningFormat::vfwredusum_vs({{
+                        Vd_vwu[0] = reduce_loop([](const vwu& src1, const vu& src2) {
+                            return fadd<ewt>(ftype<ewt>(src1), f_to_wf<et>(ftype<et>(src2)));
+                        }, Vs1_vwu, Vs2_vu);
+                    }}, OPFVV, VectorDummyOp);
+                    0x33: VectorReduceFloatWideningFormat::vfwredosum_vs({{
+                        Vd_vwu[0] = reduce_loop([](const vwu& src1, const vu& src2) {
+                            return fadd<ewt>(ftype<ewt>(src1), f_to_wf<et>(ftype<et>(src2)));
+                        }, Vs1_vwu, Vs2_vu);
+                    }}, OPFVV, VectorDummyOp);
                 }
                 format VectorFloatWideningFormat {
                     0x30: vfwadd_vv({{

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -3418,6 +3418,9 @@ decode QUADRANT default Unknown::unknown() {
                         res = int_rounding<__uint128_t>(res, 0 /* TODO */, 1);
                         Vd_vi[i] = res >> 1;
                     }}, OPMVX, VectorDummyOp);
+                    0x10: VectorNonSplitFormat::vmv_s_x({{ // Special case of OPMVX
+                        Vd_vu[0] = Rs1_vu;
+                    }}, OPMVX, VectorDummyOp);
                     0x0a: vasubu_vx({{
                         __uint128_t res = (__uint128_t)Vs2_vu[i] - Rs1_vu;
                         res = int_rounding<__uint128_t>(res, 0 /* TODO */, 1);

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2071,6 +2071,20 @@ decode QUADRANT default Unknown::unknown() {
                     0x29: vsra_vv({{
                         Vd_vi[i] = Vs2_vi[i] >> (Vs1_vu[i] & (sew - 1));
                     }}, OPIVV, VectorDummyOp);
+                    0x2a: vssrl_vv({{
+                        int sh = Vs1_vu[i] & (sew - 1);
+                        __uint128_t val = Vs2_vu[i];
+
+                        val = int_rounding<__uint128_t>(val, xc->readMiscReg(MISCREG_VXRM), sh);
+                        Vd_vu[i] = val >> sh;
+                    }}, OPIVV, VectorDummyOp);
+                    0x2b: vssra_vv({{
+                        int sh = Vs1_vi[i] & (sew - 1);
+                        __int128_t val = Vs2_vi[i];
+
+                        val = int_rounding<__int128_t>(val, xc->readMiscReg(MISCREG_VXRM), sh);
+                        Vd_vi[i] = val >> sh;
+                    }}, OPIVV, VectorDummyOp);
                 }
                 format VectorIntMaskFormat {
                     0x11: decode VM {
@@ -2835,6 +2849,13 @@ decode QUADRANT default Unknown::unknown() {
                     0x29: vsra_vi({{
                         Vd_vi[i] = Vs2_vi[i] >> ((vu)SIMM5 & (sew - 1) & 0x1f);
                     }}, OPIVI, VectorDummyOp);
+                    0x2b: vssra_vi({{
+                        int sh = SIMM5 & (sew - 1);
+                        __int128_t val = Vs2_vi[i];
+
+                        val = int_rounding<__int128_t>(val, xc->readMiscReg(MISCREG_VXRM), sh);
+                        Vd_vi[i] = val >> sh;
+                    }}, OPIVI, VectorDummyOp);
                 }
                 // According to Spec Section 16.6,
                 // vm must be 1 (unmasked) in vmv<nr>r.v instructions.
@@ -3050,6 +3071,20 @@ decode QUADRANT default Unknown::unknown() {
                     }}, OPIVX, VectorDummyOp);
                     0x29: vsra_vx({{
                         Vd_vi[i] = Vs2_vi[i] >> (Rs1_vu & (sew - 1));
+                    }}, OPIVX, VectorDummyOp);
+                    0x2a: vssrl_vx({{
+                        int sh = Rs1_vu & (sew - 1);
+                        __uint128_t val = Vs2_vu[i];
+
+                        val = int_rounding<__uint128_t>(val, xc->readMiscReg(MISCREG_VXRM), sh);
+                        Vd_vu[i] = val >> sh;
+                    }}, OPIVX, VectorDummyOp);
+                    0x2b: vssra_vx({{
+                        int sh = Rs1_vu & (sew - 1);
+                        __int128_t val = Vs2_vi[i];
+
+                        val = int_rounding<__int128_t>(val, xc->readMiscReg(MISCREG_VXRM), sh);
+                        Vd_vi[i] = val >> sh;
                     }}, OPIVX, VectorDummyOp);
                 }
                 format VectorIntNarrowingFormat {

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -3201,37 +3201,37 @@ decode QUADRANT default Unknown::unknown() {
                 format VectorFloatFormat{
                     0x00: vfadd_vf({{
                         auto fd = fadd<et>(ftype<et>(Vs2_vu[i]),
-                                           ftype<et>((vu)Fs1_bits));
+                                           ftype_freg<et>(freg(Fs1_bits)));
                         Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x02: vfsub_vf({{
                         auto fd = fsub<et>(ftype<et>(Vs2_vu[i]),
-                                           ftype<et>((vu)Fs1_bits));
+                                           ftype_freg<et>(freg(Fs1_bits)));
                         Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x04: vfmin_vf({{
                         auto fd = fmin<et>(ftype<et>(Vs2_vu[i]),
-                                           ftype<et>((vu)Fs1_bits));
+                                           ftype_freg<et>(freg(Fs1_bits)));
                         Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x06: vfmax_vf({{
                         auto fd = fmax<et>(ftype<et>(Vs2_vu[i]),
-                                           ftype<et>((vu)Fs1_bits));
+                                           ftype_freg<et>(freg(Fs1_bits)));
                             Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x08: vfsgnj_vf({{
                         Vd_vu[i] = fsgnj<et>(ftype<et>(Vs2_vu[i]),
-                                             ftype<et>((vu)Fs1_bits),
+                                             ftype_freg<et>(freg(Fs1_bits)),
                                              false, false).v;
                     }}, OPFVF, VectorDummyOp);
                     0x09: vfsgnjn_vf({{
                         Vd_vu[i] = fsgnj<et>(ftype<et>(Vs2_vu[i]),
-                                             ftype<et>((vu)Fs1_bits),
+                                             ftype_freg<et>(freg(Fs1_bits)),
                                              true, false).v;
                     }}, OPFVF, VectorDummyOp);
                     0x0a: vfsgnjx_vf({{
                         Vd_vu[i] = fsgnj<et>(ftype<et>(Vs2_vu[i]),
-                                             ftype<et>((vu)Fs1_bits),
+                                             ftype_freg<et>(freg(Fs1_bits)),
                                              false, true).v;
                     }}, OPFVF, VectorDummyOp);
                     0x10: VectorNonSplitFormat::vfmv_s_f({{
@@ -3241,7 +3241,7 @@ decode QUADRANT default Unknown::unknown() {
                     0x17: decode VM {
                         0x0: vfmerge_vfm({{
                             Vd_vu[i] = elem_mask(v0, ei)
-                                    ? ftype<et>((vu)Fs1_bits).v
+                                    ? ftype_freg<et>(freg(Fs1_bits)).v
                                     : Vs2_vu[i];
                         }}, OPFVF, VectorDummyOp);
                         0x1: vfmv_v_f({{
@@ -3254,99 +3254,99 @@ decode QUADRANT default Unknown::unknown() {
                     0x18: vmfeq_vf({{
                         Vd_ub[(i + offset)/8] = ASSIGN_VD_BIT(i + offset,
                             feq<et>(ftype<et>(Vs2_vu[i]),
-                                    ftype<et>((vu)Fs1_bits)));
+                                    ftype_freg<et>(freg(Fs1_bits))));
                     }}, OPFVF, VectorFloatOp);
                     0x19: vmfle_vf({{
                         Vd_ub[(i + offset)/8] = ASSIGN_VD_BIT(i + offset,
                             fle<et>(ftype<et>(Vs2_vu[i]),
-                                    ftype<et>((vu)Fs1_bits)));
+                                    ftype_freg<et>(freg(Fs1_bits))));
                     }}, OPFVF, VectorDummyOp);
                     0x1b: vmflt_vf({{
                         Vd_ub[(i + offset)/8] = ASSIGN_VD_BIT(i + offset,
                             flt<et>(ftype<et>(Vs2_vu[i]),
-                                    ftype<et>((vu)Fs1_bits)));
+                                    ftype_freg<et>(freg(Fs1_bits))));
                     }}, OPFVF, VectorDummyOp);
                     0x1c: vmfne_vf({{
                         Vd_ub[(i + offset)/8] = ASSIGN_VD_BIT(i + offset,
                             !feq<et>(ftype<et>(Vs2_vu[i]),
-                                     ftype<et>((vu)Fs1_bits)));
+                                     ftype_freg<et>(freg(Fs1_bits))));
                     }}, OPFVF, VectorDummyOp);
                     0x1d: vmfgt_vf({{
                         Vd_ub[(i + offset)/8] = ASSIGN_VD_BIT(i + offset,
-                            flt<et>(ftype<et>((vu)Fs1_bits),
+                            flt<et>(ftype_freg<et>(freg(Fs1_bits)),
                                     ftype<et>(Vs2_vu[i])));
                     }}, OPFVF, VectorDummyOp);
                     0x1f: vmfge_vf({{
                         Vd_ub[(i + offset)/8] = ASSIGN_VD_BIT(i + offset,
-                            fle<et>(ftype<et>((vu)Fs1_bits),
+                            fle<et>(ftype_freg<et>(freg(Fs1_bits)),
                                     ftype<et>(Vs2_vu[i])));
                     }}, OPFVF, VectorDummyOp);
                 }
                 format VectorFloatFormat{
                     0x20: vfdiv_vf({{
                         auto fd = fdiv<et>(ftype<et>(Vs2_vu[i]),
-                                           ftype<et>((vu)Fs1_bits));
+                                           ftype_freg<et>(freg(Fs1_bits)));
                         Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x21: vfrdiv_vf({{
-                        auto fd = fdiv<et>(ftype<et>((vu)Fs1_bits),
+                        auto fd = fdiv<et>(ftype_freg<et>(freg(Fs1_bits)),
                                            ftype<et>(Vs2_vu[i]));
                         Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x24: vfmul_vf({{
                         auto fd = fmul<et>(ftype<et>(Vs2_vu[i]),
-                                           ftype<et>((vu)Fs1_bits));
+                                           ftype_freg<et>(freg(Fs1_bits)));
                         Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x27: vfrsub_vf({{
-                        auto fd = fsub<et>(ftype<et>((vu)Fs1_bits),
+                        auto fd = fsub<et>(ftype_freg<et>(freg(Fs1_bits)),
                                            ftype<et>(Vs2_vu[i]));
                         Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x28: vfmadd_vf({{
                         auto fd = fmadd<et>(ftype<et>(Vs3_vu[i]),
-                                            ftype<et>((vu)Fs1_bits),
+                                            ftype_freg<et>(freg(Fs1_bits)),
                                             ftype<et>(Vs2_vu[i]));
                         Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x29: vfnmadd_vf({{
                         auto fd = fmadd<et>(fneg(ftype<et>(Vs3_vu[i])),
-                                            ftype<et>((vu)Fs1_bits),
+                                            ftype_freg<et>(freg(Fs1_bits)),
                                             fneg(ftype<et>(Vs2_vu[i])));
                         Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x2a: vfmsub_vf({{
                         auto fd = fmadd<et>(ftype<et>(Vs3_vu[i]),
-                                            ftype<et>((vu)Fs1_bits),
+                                            ftype_freg<et>(freg(Fs1_bits)),
                                             fneg(ftype<et>(Vs2_vu[i])));
                         Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x2b: vfnmsub_vf({{
                         auto fd = fmadd<et>(fneg(ftype<et>(Vs3_vu[i])),
-                                            ftype<et>((vu)Fs1_bits),
+                                            ftype_freg<et>(freg(Fs1_bits)),
                                             ftype<et>(Vs2_vu[i]));
                         Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x2c: vfmacc_vf({{
-                        auto fd = fmadd<et>(ftype<et>((vu)Fs1_bits),
+                        auto fd = fmadd<et>(ftype_freg<et>(freg(Fs1_bits)),
                                             ftype<et>(Vs2_vu[i]),
                                             ftype<et>(Vs3_vu[i]));
                         Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x2d: vfnmacc_vf({{
-                        auto fd = fmadd<et>(fneg(ftype<et>((vu)Fs1_bits)),
+                        auto fd = fmadd<et>(fneg(ftype_freg<et>(freg(Fs1_bits))),
                                             ftype<et>(Vs2_vu[i]),
                                             fneg(ftype<et>(Vs3_vu[i])));
                         Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x2e: vfmsac_vf({{
-                        auto fd = fmadd<et>(ftype<et>((vu)Fs1_bits),
+                        auto fd = fmadd<et>(ftype_freg<et>(freg(Fs1_bits)),
                                             ftype<et>(Vs2_vu[i]),
                                             fneg(ftype<et>(Vs3_vu[i])));
                         Vd_vu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x2f: vfnmsac_vf({{
-                        auto fd = fmadd<et>(fneg(ftype<et>((vu)Fs1_bits)),
+                        auto fd = fmadd<et>(fneg(ftype_freg<et>(freg(Fs1_bits))),
                                             ftype<et>(Vs2_vu[i]),
                                             ftype<et>(Vs3_vu[i]));
                         Vd_vu[i] = fd.v;
@@ -3356,57 +3356,57 @@ decode QUADRANT default Unknown::unknown() {
                     0x30: vfwadd_vf({{
                         auto fd = fadd<ewt>(
                             fwiden(ftype<et>(Vs2_vu[i + offset])),
-                            fwiden(ftype<et>((vu)Fs1_bits)));
+                            fwiden(ftype_freg<et>(freg(Fs1_bits))));
                         Vd_vwu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x32: vfwsub_vf({{
                         auto fd = fsub<ewt>(
                             fwiden(ftype<et>(Vs2_vu[i + offset])),
-                            fwiden(ftype<et>((vu)Fs1_bits)));
+                            fwiden(ftype_freg<et>(freg(Fs1_bits))));
                         Vd_vwu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x34: vfwadd_wf({{
                         auto fd = fadd<ewt>(
                             ftype<ewt>(Vs2_vwu[i]),
-                            fwiden(ftype<et>((vu)Fs1_bits)));
+                            fwiden(ftype_freg<et>(freg(Fs1_bits))));
                         Vd_vwu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x36: vfwsub_wf({{
                         auto fd = fsub<ewt>(
                             ftype<ewt>(Vs2_vwu[i]),
-                            fwiden(ftype<et>((vu)Fs1_bits)));
+                            fwiden(ftype_freg<et>(freg(Fs1_bits))));
                         Vd_vwu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x38: vfwmul_vf({{
                         auto fd = fmul<ewt>(
                             fwiden(ftype<et>(Vs2_vu[i + offset])),
-                            fwiden(ftype<et>((vu)Fs1_bits)));
+                            fwiden(ftype_freg<et>(freg(Fs1_bits))));
                         Vd_vwu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x3c: vfwmacc_vf({{
                         auto fd = fmadd<ewt>(
-                            fwiden(ftype<et>((vu)Fs1_bits)),
+                            fwiden(ftype_freg<et>(freg(Fs1_bits))),
                             fwiden(ftype<et>(Vs2_vu[i + offset])),
                             ftype<ewt>(Vs3_vwu[i]));
                         Vd_vwu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x3d: vfwnmacc_vf({{
                         auto fd = fmadd<ewt>(
-                            fwiden(fneg(ftype<et>((vu)Fs1_bits))),
+                            fwiden(fneg(ftype_freg<et>(freg(Fs1_bits)))),
                             fwiden(ftype<et>(Vs2_vu[i + offset])),
                             fneg(ftype<ewt>(Vs3_vwu[i])));
                         Vd_vwu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x3e: vfwmsac_vf({{
                         auto fd = fmadd<ewt>(
-                            fwiden(ftype<et>((vu)Fs1_bits)),
+                            fwiden(ftype_freg<et>(freg(Fs1_bits))),
                             fwiden(ftype<et>(Vs2_vu[i + offset])),
                             fneg(ftype<ewt>(Vs3_vwu[i])));
                         Vd_vwu[i] = fd.v;
                     }}, OPFVF, VectorDummyOp);
                     0x3f: vfwnmsac_vf({{
                         auto fd = fmadd<ewt>(
-                            fwiden(fneg(ftype<et>((vu)Fs1_bits))),
+                            fwiden(fneg(ftype_freg<et>(freg(Fs1_bits)))),
                             fwiden(ftype<et>(Vs2_vu[i + offset])),
                             ftype<ewt>(Vs3_vwu[i]));
                         Vd_vwu[i] = fd.v;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2604,6 +2604,11 @@ decode QUADRANT default Unknown::unknown() {
                         }}, OPMVV, VectorDummyOp);
                     }
                 }
+                0x14: decode RS1 {
+                    0x11: VectorIntFormat::vid_v({{
+                        Vd_vu[i] = ei;
+                    }}, OPMVV, VectorDummyOp);
+                }
                 format VectorMaskFormat {
                     0x18: vmandn_mm({{
                         Vd_ub[i/8] = ASSIGN_VD_BIT(i,

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -788,14 +788,21 @@ def format VectorNonSplitFormat(code, category, *flags) {{
          'vm_decl_rd': vm_decl_rd,
          'set_vm_idx': set_vm_idx},
         flags)
+
+    if inst_name == "vfmv" :
+        execute_block = VectorFloatNonSplitExecute.subst(iop)
+        decode_block = VectorFloatDecodeBlock.subst(iop)
+    else :
+        execute_block = VectorNonSplitExecute.subst(iop)
+        decode_block = VectorIntDecodeBlock.subst(iop)
+
     # Because of the use of templates, we had to put all parts in header to
     # keep the compiler happy.
     header_output = \
         VectorNonSplitDeclare.subst(iop) + \
         VectorNonSplitConstructor.subst(iop) + \
-        VectorNonSplitExecute.subst(iop)
+        execute_block
 
-    decode_block = VectorIntDecodeBlock.subst(iop)
 }};
 
 def format VectorMaskFormat(code, category, *flags) {{

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -73,25 +73,41 @@ let {{
 
 
 def format VectorIntFormat(code, category, *flags) {{
-    iop = InstObjParams(name, Name, 'VectorArithMacroInst', {'code': code},
+    macroop_class_name = 'VectorArithMacroInst'
+    microop_class_name = 'VectorArithMicroInst'
+
+    if name == "vid_v" :
+        macroop_class_name = 'VectorVMUNARY0MacroInst'
+        microp_class_name = 'VectorVMUNARY0MicroInst'
+
+    iop = InstObjParams(name, Name, macroop_class_name, {'code': code},
                         flags)
     inst_name, inst_suffix = name.split("_", maxsplit=1)
     v0_required = inst_name not in ["vmv"]
     mask_cond = v0_required and (inst_suffix not in ['vvm', 'vxm', 'vim'])
     need_elem_idx = mask_cond or code.find("ei") != -1
-    old_vd_idx = 2
+
     dest_reg_id = "vecRegClass[_machInst.vd + _microIdx]"
+
+    num_src_regs = 0
+
+    src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
+    num_src_regs += 1
+
     src1_reg_id = ""
     if category in ["OPIVV", "OPMVV"]:
         src1_reg_id = "vecRegClass[_machInst.vs1 + _microIdx]"
+        num_src_regs += 1
     elif category in ["OPIVX", "OPMVX"]:
         src1_reg_id = "intRegClass[_machInst.rs1]"
+        num_src_regs += 1
     elif category == "OPIVI":
-        old_vd_idx = 1
+        pass
     else:
         error("not supported category for VectorIntFormat: %s" % category)
-    src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
-    src3_reg_id = "vecRegClass[_machInst.vs3 + _microIdx]"
+
+    old_vd_idx = num_src_regs
+    src3_reg_id = "vecRegClass[_machInst.vd + _microIdx]"
 
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
 
@@ -116,7 +132,7 @@ def format VectorIntFormat(code, category, *flags) {{
 
     microiop = InstObjParams(name + "_micro",
         Name + "Micro",
-        'VectorArithMicroInst',
+        microop_class_name,
         {'code': code,
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -931,6 +931,50 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
     decode_block = VectorFloatDecodeBlock.subst(iop)
 }};
 
+def format VectorReduceFloatWideningFormat(code, category, *flags) {{
+    iop = InstObjParams(name, Name, 'VectorArithMacroInst', {'code': code},
+                        flags)
+    inst_name, inst_suffix = name.split("_", maxsplit=1)
+    dest_reg_id = "vecRegClass[_machInst.vd]"
+    src1_reg_id = "vecRegClass[_machInst.vs1]"
+    src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
+    old_dest_reg_id = "vecRegClass[_machInst.vd]"
+    set_dest_reg_idx = setDestWrapper(dest_reg_id)
+    set_src_reg_idx = setSrcWrapper(src1_reg_id)
+    set_src_reg_idx += setSrcWrapper(src2_reg_id)
+    # Treat tail undisturbed/agnostic as the same
+    # We always need old rd as src vreg
+    set_src_reg_idx += setSrcWrapper(old_dest_reg_id)
+    set_src_reg_idx += setSrcVm()
+    vm_decl_rd = vmDeclAndReadData()
+    type_def = '''
+        using et = ElemType;
+        using vu [[maybe_unused]] = decltype(et::v);
+        using ewt = typename double_width<et>::type;
+        using vwu = decltype(ewt::v);
+    '''
+    microiop = InstObjParams(name + "_micro",
+        Name + "Micro",
+        'VectorArithMicroInst',
+        {'code': code,
+         'set_dest_reg_idx': set_dest_reg_idx,
+         'set_src_reg_idx': set_src_reg_idx,
+         'vm_decl_rd': vm_decl_rd,
+         'type_def': type_def,
+         'copy_old_vd': copyOldVd(2)},
+        flags)
+
+    # Because of the use of templates, we had to put all parts in header to
+    # keep the compiler happy.
+    header_output = \
+        VectorReduceMicroDeclare.subst(microiop) + \
+        VectorReduceMicroConstructor.subst(microiop) + \
+        VectorReduceFloatWideningMicroExecute.subst(microiop) + \
+        VectorReduceMacroDeclare.subst(iop) + \
+        VectorReduceMacroConstructor.subst(iop)
+    decode_block = VectorFloatWideningDecodeBlock.subst(iop)
+}};
+
 def format VectorIntVxsatFormat(code, category, *flags) {{
     iop = InstObjParams(name, Name, 'VectorArithMacroInst', {'code': code},
                         flags)

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -1085,18 +1085,16 @@ Fault
     %(vm_decl_rd)s;
     %(copy_old_vd)s;
 
-    Vd[0] = this->microIdx != 0 ? old_Vd[0] : Vs1[0];
-
     auto reduce_loop =
         [&, this](const auto& f, const auto* _, const auto* vs2) {
-            ElemType tmp_val = Vd[0];
+            ElemType microop_result = this->microIdx != 0 ? old_Vd[0] : Vs1[0];;
             for (uint32_t i = 0; i < this->microVl; i++) {
                 uint32_t ei = i + vtype_VLMAX(vtype, true) * this->microIdx;
                 if (this->vm || elem_mask(v0, ei)) {
-                    tmp_val = f(tmp_val, Vs2[i]);
+                    microop_result = f(microop_result, Vs2[i]);
                 }
             }
-            return tmp_val;
+            return microop_result;
         };
 
     %(code)s;

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -504,7 +504,7 @@ private:
 public:
     %(class_name)s(ExtMachInst _machInst);
     std::string generateDisassembly(Addr pc,
-        const loader::SymbolTable *symtab) const
+        const loader::SymbolTable *symtab) const override
     {
         std::stringstream ss;
         ss << mnemonic << ' ' << registerName(destRegIdx(0)) << ", "
@@ -530,7 +530,7 @@ public:
         uint8_t _microVl, uint8_t _microIdx);
     Fault execute(ExecContext* xc, Trace::InstRecord* traceData)const override;
     std::string generateDisassembly(Addr pc,
-        const loader::SymbolTable *symtab) const
+        const loader::SymbolTable *symtab) const override
     {
         std::stringstream ss;
         ss << mnemonic << ' ' << registerName(destRegIdx(0)) << ", "

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -1163,6 +1163,43 @@ Fault
 
 }};
 
+def template VectorReduceFloatWideningMicroExecute {{
+
+template <typename ElemType>
+Fault
+%(class_name)s<ElemType>::execute(ExecContext* xc,
+                                  Trace::InstRecord* traceData) const
+{
+    %(type_def)s;
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
+
+    %(op_decl)s;
+    %(op_rd)s;
+    %(vm_decl_rd)s;
+    %(copy_old_vd)s;
+
+    Vd[0] = this->microIdx != 0 ? old_Vd[0] : Vs1[0];
+
+    auto reduce_loop =
+        [&, this](const auto& f, const auto* _, const auto* vs2) {
+            vwu tmp_val = Vd[0];
+            for (uint32_t i = 0; i < this->microVl; i++) {
+                uint32_t ei = i + vtype_VLMAX(vtype, true) * this->microIdx;
+                if (this->vm || elem_mask(v0, ei)) {
+                    tmp_val = f(tmp_val, Vs2[i]).v;
+                }
+            }
+            return tmp_val;
+        };
+
+    %(code)s;
+    %(op_wb)s;
+    return NoFault;
+}
+
+}};
+
 def template VectorGatherMacroDeclare {{
 
 template<typename ElemType, typename IndexType>

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -202,8 +202,7 @@ Fault
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
 
     auto SEW = vtype_SEW(vtype);
-    const int32_t micro_vlmax = vtype_VLMAX(vtype, true);
-    auto offset = ((microIdx % %(ext_div)d) * micro_vlmax) / %(ext_div)d;
+    auto offset = (VLEN / SEW) * (microIdx % %(ext_div)d);
     switch (SEW / %(ext_div)d) {
       case 8: {
         using vext  [[maybe_unused]] = int8_t;

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -550,7 +550,7 @@ Fault
                                   Trace::InstRecord* traceData) const
 {
     using et = ElemType;
-    using vu = decltype(et::v);
+    using vu [[maybe_unused]] = decltype(et::v);
     using ewt = typename double_width<et>::type;
     using vwu = decltype(ewt::v);
 

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -993,6 +993,28 @@ Fault
 
 }};
 
+def template VectorFloatNonSplitExecute {{
+
+template <typename ElemType>
+Fault
+%(class_name)s<ElemType>::execute(ExecContext* xc,
+                                    Trace::InstRecord* traceData) const
+{
+    using et = ElemType;
+    using vu = decltype(et::v);
+
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
+    %(op_decl)s;
+    %(op_rd)s;
+    %(vm_decl_rd)s;
+    %(code)s;
+    %(op_wb)s;
+    return NoFault;
+}
+
+}};
+
 def template VectorReduceMacroDeclare {{
 
 template<typename ElemType>

--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -19,10 +19,9 @@ def template VleConstructor {{
     %(set_reg_idx_arr)s;
     %(constructor)s;
 
-    const int32_t emul = get_emul(_machInst.width, vtype);
-    const uint32_t num_microops = emul < 0 ? 1 : 1 << emul;
-    int32_t remaining_vl = this->vl;
     const int32_t micro_vlmax = VLEN / width_EEW(_machInst.width);
+    const uint32_t num_microops = ceil((float) this->vl / (micro_vlmax));
+    int32_t remaining_vl = this->vl;
     int32_t micro_vl = std::min(remaining_vl, micro_vlmax);
     StaticInstPtr microop;
 
@@ -173,10 +172,9 @@ def template VseConstructor {{
     %(set_reg_idx_arr)s;
     %(constructor)s;
 
-    const int32_t emul = get_emul(_machInst.width, vtype);
-    const uint32_t num_microops = emul < 0 ? 1 : 1 << emul;
-    int32_t remaining_vl = this->vl;
     const int32_t micro_vlmax = VLEN / width_EEW(_machInst.width);
+    const uint32_t num_microops = ceil((float) this->vl / (micro_vlmax));
+    int32_t remaining_vl = this->vl;
     int32_t micro_vl = std::min(remaining_vl, micro_vlmax);
 
     StaticInstPtr microop;

--- a/src/arch/riscv/utility.hh
+++ b/src/arch/riscv/utility.hh
@@ -311,6 +311,18 @@ ftype(IntType a) -> FloatType
     GEM5_UNREACHABLE;
 }
 
+// TODO: Consolidate ftype_freg(freg_t a) and ftype(IntType a) into a
+// single function
+template<typename FloatType, typename IntType = decltype(FloatType::v)> auto
+ftype_freg(freg_t a) -> FloatType
+{
+    if constexpr(std::is_same_v<uint32_t, IntType>)
+        return f32(a);
+    else if constexpr(std::is_same_v<uint64_t, IntType>)
+        return f64(a);
+    GEM5_UNREACHABLE;
+}
+
 template<typename FloatType> FloatType
 fadd(FloatType a, FloatType b)
 {

--- a/src/arch/riscv/utility.hh
+++ b/src/arch/riscv/utility.hh
@@ -211,36 +211,6 @@ width_EEW(uint64_t width)
     }
 }
 
-/**
- * Encode EMUL to emul as follows:
- *     EMUL   emul
- *      1       0
- *      2       1
- *      4       2
- *      8       3
- *      -       -
- *     1/8     -3
- *     1/4     -2
- *     1/2     -1
- * @param mew_width mew << 3 | width
- * @param vtype
- * @return int32_t
- */
-inline int32_t
-get_emul(const uint64_t mew_width, const uint64_t vtype)
-{
-    panic_if(mew_width > 0x7, "encodings with mew=1 are reserved");
-    int32_t i_eew = mew_width  == 0 ? 0 : mew_width - 0x4;
-    int32_t i_sew = bits(vtype, 5, 3);
-    int32_t vlmul = bits(vtype, 2, 0);
-    int32_t emul = i_eew - i_sew + vlmul;
-    panic_if(emul > 3, "encodings with EMUL=%u are reserved",
-        uint32_t(8 << emul));
-    panic_if(emul < -3, "encodings with EMUL=1/%u are reserved",
-        uint32_t(8 << -emul));
-    return emul;
-}
-
 /*
   *  Spec Section 4.5
   *  Ref:


### PR DESCRIPTION
I've validated these changes against our internal directed tests. 

I wanted to point out this commit that adds support for the Indexed loads/stores:

```
* bee820d76 - HITS PANIC: arch-riscv: Added support for the indexed loads/stores. (7 minutes ago) <Jerin Joy>
```

I'm able to run indexed loads/stores through our model with these changes but the instructions cause a panic to be triggered on the PLCT model:

```
panic: panic condition !handled && !tc->getSystemPtr()->trapToGdb(SIGSEGV, tc->contextId()) occurred: Page table fault when accessing virtual address
```

I included it in this PR because I thought you guys would have a better understanding of what's causing this failure in the your model.